### PR TITLE
Fix atomicAdd on minGW compiler

### DIFF
--- a/base/funknown.cpp
+++ b/base/funknown.cpp
@@ -84,7 +84,7 @@ namespace FUnknownPrivate {
 int32 PLUGIN_API atomicAdd (int32& var, int32 d)
 {
 #if SMTG_OS_WINDOWS
-	return InterlockedExchangeAdd (&var, d) + d;
+	return InterlockedExchangeAdd ((LONG*)&var, d) + d;
 #elif SMTG_OS_MACOS
 #if SMTG_MACOS_USE_STDATOMIC
 	return atomic_fetch_add (reinterpret_cast<atomic_int_least32_t*> (&var), d) + d;


### PR DESCRIPTION
It would not build on MinGW-w64 GCC 9.2.1.

The error was:

```
/home/jpc/documents/projects/sfizz/vst/external/VST_SDK/VST3_SDK/pluginterfaces/base/funknown.cpp: In function 'Steinberg::int32 Steinberg::FUnknownPrivate::atomicAdd(Steinberg::int32&, Steinberg::int32)':
/home/jpc/documents/projects/sfizz/vst/external/VST_SDK/VST3_SDK/pluginterfaces/base/funknown.cpp:87:40: error: no matching function for call to '_InterlockedExchangeAdd(Steinberg::int32*, Steinberg::int32&)'
   87 |  return InterlockedExchangeAdd (&var, d) + d;
```