### PR TITLE
Fix ‘atomic_int_least32_t’ does not name a type compilation error

### DIFF
--- a/base/funknown.cpp
+++ b/base/funknown.cpp
@@ -57,6 +57,7 @@
 
 #if defined (SMTG_USE_STDATOMIC_H) && SMTG_USE_STDATOMIC_H 
 #include <stdatomic.h>
+#include <atomic> // to provide atomic_int_least32_t
 #endif
 
 namespace Steinberg {
@@ -88,7 +89,7 @@ namespace FUnknownPrivate {
 int32 PLUGIN_API atomicAdd (int32& var, int32 d)
 {
 #if SMTG_USE_STDATOMIC_H
-	return atomic_fetch_add (reinterpret_cast<atomic_int_least32_t*> (&var), d) + d;
+	return atomic_fetch_add (reinterpret_cast<std::atomic_int_least32_t*> (&var), d) + d;
 #else
 #if SMTG_OS_WINDOWS
 #ifdef __MINGW32__


### PR DESCRIPTION
std::atomic_int_least32_t is defined in atomic header, and not stdatomic.
This caused compilation error locally on gcc 12.2.0. 